### PR TITLE
Add support for table arrays

### DIFF
--- a/src/test/scala/api/TomlParserApiSpec.scala
+++ b/src/test/scala/api/TomlParserApiSpec.scala
@@ -4,6 +4,7 @@ import fastparse.core.Parsed.{Failure, Success}
 import org.scalatest.{FunSpec, Matchers}
 
 class TomlParserApiSpec extends FunSpec with Matchers {
+  import stoml.Toml._
   import stoml.TomlParserApi._
 
   val smallFileTest =
@@ -41,6 +42,41 @@ class TomlParserApiSpec extends FunSpec with Matchers {
           assert(subkeys(0).elem.isInstanceOf[(Any, Any)])
         case f: Failure[_, _] =>
           fail("`toToml` has not parsed correctly the file")
+      }
+    }
+
+    it("should parse parse table arrays") {
+      val array =
+        """
+          |[[products]]
+          |name = "Hammer"
+          |sku = 738594937
+          |colour = "blue"
+          |
+          |[[products]]
+          |name = "Nail"
+          |sku = 284758393
+          |colour = "grey"
+        """.stripMargin
+
+      parseToml(array) match {
+        case Success(v, _) =>
+          val p = v.lookup("products")
+          println(p)
+          assert(p.contains(TableArrayItems(List(
+            TableArray("products", List(
+              Pair("name" -> Str("Hammer")),
+              Pair("sku" -> Integer(738594937)),
+              Pair("colour" -> Str("blue"))
+            )),
+            TableArray("products", List(
+              Pair("name" -> Str("Nail")),
+              Pair("sku" -> Integer(284758393)),
+              Pair("colour" -> Str("grey"))
+            ))
+          ))))
+
+        case f: Failure[_, _] => fail()
       }
     }
   }

--- a/src/test/scala/stoml/ArrayTomlSpec.scala
+++ b/src/test/scala/stoml/ArrayTomlSpec.scala
@@ -11,16 +11,14 @@ trait ArrayTomlGen {
     with StringTomlGen
     with NumbersTomlGen =>
 
-  val openChars = List("[", "[\n")
-  val seps = List(",\n", ",")
-  val closeChars = List("]", "\n]")
-
   def arrayFormat(s: Seq[_], fs: (String, String, String)): String =
     fs._1 + (s mkString fs._2) + fs._3
 
   import Gen.{nonEmptyListOf, oneOf}
 
-  def arrayGen = for {
+  def arrayGen(openChars: List[String],
+               seps: List[String],
+               closeChars: List[String]) = for {
     ts <- oneOf(validStrGen, validDoubleGen, validLongGen)
     elems <- nonEmptyListOf(ts)
     c1 <- oneOf(openChars)
@@ -36,7 +34,22 @@ class ArrayTomlSpec extends PropSpec
     with TestParserUtil {
 
   property("parse arrays") {
-    forAll(arrayGen) {
+    val openChars = List("[", "[\n")
+    val seps = List(",\n", ",")
+    val closeChars = List("]", "\n]")
+
+    forAll(arrayGen(openChars, seps, closeChars)) {
+      s: String =>
+        shouldBeSuccess(elem.parse(s))
+    }
+  }
+
+  property("parse table arrays") {
+    val openChars = List("[[", "[[\n")
+    val seps = List(",\n", ",")
+    val closeChars = List("]]", "\n]]")
+
+    forAll(arrayGen(openChars, seps, closeChars)) {
       s: String =>
         shouldBeSuccess(elem.parse(s))
     }


### PR DESCRIPTION
This adds preliminary support for table arrays. The following shortened example from the TOML reference will require further changes to the current design:

```toml
[[fruit]]
  name = "apple"

  [fruit.physical]
    colour = "red"
    shape = "round"
```

A solution could be to resolve the child to an inline table:

```toml
[[fruit]]
  name = "apple"
  physical = { colour = "red", shape = "round" }
```

I will add support for inline tables in a follow-up pull request.