### PR TITLE
Add support for inline tables

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 0.13.16

--- a/src/test/scala/api/TomlParserApiSpec.scala
+++ b/src/test/scala/api/TomlParserApiSpec.scala
@@ -45,7 +45,7 @@ class TomlParserApiSpec extends FunSpec with Matchers {
       }
     }
 
-    it("should parse parse table arrays") {
+    it("should parse table arrays") {
       val array =
         """
           |[[products]]
@@ -62,7 +62,6 @@ class TomlParserApiSpec extends FunSpec with Matchers {
       parseToml(array) match {
         case Success(v, _) =>
           val p = v.lookup("products")
-          println(p)
           assert(p.contains(TableArrayItems(List(
             TableArray("products", List(
               Pair("name" -> Str("Hammer")),
@@ -75,6 +74,28 @@ class TomlParserApiSpec extends FunSpec with Matchers {
               Pair("colour" -> Str("grey"))
             ))
           ))))
+
+        case f: Failure[_, _] => fail()
+      }
+    }
+
+    it("should parse inline table arrays") {
+      val array =
+        """
+          |product = {
+          |  name   = "Hammer",
+          |  colour = "blue"
+          |}
+        """.stripMargin
+
+      parseToml(array) match {
+        case Success(v, _) =>
+          val p = v.lookup("product")
+          assert(p.contains(
+            Table("", List(
+              Pair("name" -> Str("Hammer")),
+              Pair("colour" -> Str("blue"))))
+          ))
 
         case f: Failure[_, _] => fail()
       }

--- a/src/test/scala/stoml/InlineTableTomlSpec.scala
+++ b/src/test/scala/stoml/InlineTableTomlSpec.scala
@@ -1,0 +1,75 @@
+package stoml
+
+import fastparse.core.Parsed.Success
+import org.scalacheck.Gen
+import org.scalatest.prop._
+import org.scalatest.{Matchers, PropSpec}
+
+trait InlineTableTomlGen {
+  this: TomlSymbol
+    with StringTomlGen
+    with NumbersTomlGen =>
+
+  val openChars = List("{", "{\n")
+  val seps = List(",\n", ",")
+  val closeChars = List("}", "\n}")
+
+  def bareKeyGen = Gen.someOf(
+    Gen.alphaLowerChar,
+    Gen.alphaUpperChar,
+    Gen.alphaNumChar,
+    Gen.oneOf('_', '-')
+  ).retryUntil(x => x.nonEmpty && !x.contains('=')).map(_.mkString)
+
+  private def validPairGen: Gen[(String, String)] =
+    for {
+      key   <- bareKeyGen
+      value <- Gen.oneOf(validStrGen, validDoubleGen, validLongGen)
+    } yield (key, value)
+
+  private def invalidPairGen: Gen[(String, String)] =
+    for {
+      key   <- Gen.someOf(bareKeyGen, "=").map(_.mkString)
+      value <- Gen.oneOf("", ",")
+    } yield (key, value)
+
+  def tableFormat(s: Seq[(String, String)], fs: (String, String, String)): String =
+    fs._1 +
+    s.map { case (k, v) => k + "=" + v }.mkString(fs._2) +
+    fs._3
+
+  def inlineTableGen(pairGen: Gen[(String, String)]) =
+    for {
+      elems <- Gen.nonEmptyListOf(pairGen)
+      c1 <- Gen.oneOf(openChars)
+      ss <- Gen.oneOf(seps)
+      c2 <- Gen.oneOf(closeChars)
+    } yield tableFormat(elems, (c1, ss, c2))
+
+  def validInlineTableGen  : Gen[String] = inlineTableGen(validPairGen)
+  def invalidInlineTableGen: Gen[String] = inlineTableGen(invalidPairGen)
+}
+
+class InlineTableTomlSpec extends PropSpec
+  with PropertyChecks
+  with Matchers
+  with InlineTableTomlGen
+  with StringTomlGen
+  with NumbersTomlGen
+  with TomlParser
+  with TestParserUtil {
+
+  property("parse valid inline tables") {
+    forAll(validInlineTableGen) {
+      s: String =>
+        shouldBeSuccess(elem.parse(s))
+    }
+  }
+
+  property("do not parse invalid inline tables") {
+    forAll(invalidInlineTableGen) {
+      s: String =>
+        shouldBeFailure(elem.parse(s))
+    }
+  }
+}

--- a/src/test/scala/stoml/TableTomlSpec.scala
+++ b/src/test/scala/stoml/TableTomlSpec.scala
@@ -12,7 +12,8 @@ trait TableTomlGen {
     with StringTomlGen
     with NumbersTomlGen
     with BooleanTomlGen
-    with CommentTomlGen =>
+    with CommentTomlGen
+    with InlineTableTomlGen =>
 
   val sps = List(" ", "\t")
 
@@ -38,15 +39,9 @@ trait TableTomlGen {
     validStrGen,
     validDoubleGen,
     validLongGen,
-    validBoolGen
+    validBoolGen,
+    validInlineTableGen
   )
-
-  def bareKeyGen = Gen.someOf(
-    Gen.alphaLowerChar,
-    Gen.alphaUpperChar,
-    Gen.alphaNumChar,
-    Gen.oneOf('_', '-')
-  ) suchThat (_.nonEmpty) map (_.mkString)
 
   def pairGen: Gen[String] = for {
     key <- oneOf(doubleQuoteStrGen, bareKeyGen)
@@ -75,13 +70,13 @@ trait TableTomlGen {
     c1 <- commentGen
     c2 <- commentGen
   } yield c1 + tableFormat(tdef, ps) + c2
-
 }
 
 class TableTomlSpec extends PropSpec 
     with PropertyChecks with Matchers
     with BooleanTomlGen with StringTomlGen
     with NumbersTomlGen with TableTomlGen
+    with InlineTableTomlGen
     with CommentTomlGen with TomlParser
     with TestParserUtil {
 


### PR DESCRIPTION
This pull request adds support for inline tables such as the following ones:

```toml
name = { first = "Tom", last = "Preston-Werner" }
point = { x = 1, y = 2 }
```